### PR TITLE
Add GitHub Action for Android build pipeline

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,16 +24,31 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          channel: canary
-          packages: |
+          cmdline-tools-version: latest
+          packages: |-
             platform-tools
-            platforms;android-36
-            build-tools;36.0.0-rc1
+
+      - name: Install preview SDK components
+        run: |
+          yes | sdkmanager --licenses
+          yes | sdkmanager --channel=3 "platforms;android-36" "build-tools;36.0.0-rc1"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
-      - name: Build debug APK
-        run: ./gradlew assembleDebug
+      - name: Build debug and release APKs
+        run: ./gradlew assembleDebug assembleRelease
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-apk
+          path: app/build/outputs/apk/release/*.apk


### PR DESCRIPTION
## Summary
- add an Android build workflow that runs on pushes to main and pull requests
- configure Java 21, Android SDK packages, and Gradle caching before assembling the debug APK

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68dcbea79fc88333aca0acb8015995b0