### PR TITLE
Add top app bar to main activity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 .gradle
 .idea
+build
 app/build
 
 local.properties

--- a/app/src/main/java/com/swooby/alfred/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/swooby/alfred/settings/SettingsScreen.kt
@@ -2,6 +2,7 @@ package com.swooby.alfred.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -28,7 +29,11 @@ import androidx.compose.ui.unit.dp
 import com.swooby.alfred.AlfredApp
 
 @Composable
-fun SettingsScreen(app: AlfredApp) {
+fun SettingsScreen(
+    app: AlfredApp,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues()
+) {
     val vm = settingsViewModel(app)
     val rules by vm.rules.collectAsState()
 
@@ -56,11 +61,12 @@ fun SettingsScreen(app: AlfredApp) {
         onLocalQuietEndChange = { quietEnd = it },
         onLocalDisabledAppsChange = { disabledAppsCsv = it },
         onLocalEnabledTypesChange = { enabledTypesCsv = it },
+        modifier = modifier,
+        contentPadding = contentPadding,
     )
 }
 
 /** Pure UI: easy to preview & unit-test */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsContent(
     quietStart: String,
@@ -77,75 +83,76 @@ fun SettingsContent(
     onLocalQuietEndChange: (String) -> Unit,
     onLocalDisabledAppsChange: (String) -> Unit,
     onLocalEnabledTypesChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
-    Scaffold(topBar = { TopAppBar(title = { Text("Alfred Settings") }) }) { pad ->
-        Column(
-            Modifier
-                .padding(pad)
-                .padding(16.dp)
-                .fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
+    Column(
+        modifier
+            .padding(contentPadding)
+            .padding(16.dp)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
 
-            Text("Quiet Hours (HH:mm)", style = MaterialTheme.typography.titleMedium)
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                OutlinedTextField(
-                    value = quietStart,
-                    onValueChange = onLocalQuietStartChange,
-                    label = { Text("Start e.g. 22:00") },
-                    modifier = Modifier.weight(1f)
-                )
-                OutlinedTextField(
-                    value = quietEnd,
-                    onValueChange = onLocalQuietEndChange,
-                    label = { Text("End e.g. 07:00") },
-                    modifier = Modifier.weight(1f)
-                )
-                Button(
-                    onClick = {
-                        onSaveQuietHours(
-                            quietStart.ifBlank { null },
-                            quietEnd.ifBlank { null }
-                        )
-                    }
-                ) { Text("Save") }
-            }
-
-            Row {
-                Checkbox(
-                    checked = speakScreenOff,
-                    onCheckedChange = { onSpeakScreenOffChange(it) }
-                )
-                Text("Speak only when screen is OFF", modifier = Modifier.padding(start = 8.dp))
-            }
-
-            Spacer(Modifier.height(8.dp))
-            Text(
-                "Disabled apps (CSV of package names)",
-                style = MaterialTheme.typography.titleMedium
+        Text("Quiet Hours (HH:mm)", style = MaterialTheme.typography.titleMedium)
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            OutlinedTextField(
+                value = quietStart,
+                onValueChange = onLocalQuietStartChange,
+                label = { Text("Start e.g. 22:00") },
+                modifier = Modifier.weight(1f)
             )
             OutlinedTextField(
-                value = disabledAppsCsv,
-                onValueChange = onLocalDisabledAppsChange,
-                modifier = Modifier.fillMaxWidth()
+                value = quietEnd,
+                onValueChange = onLocalQuietEndChange,
+                label = { Text("End e.g. 07:00") },
+                modifier = Modifier.weight(1f)
             )
-            Button(onClick = { onSaveDisabledApps(disabledAppsCsv) }) { Text("Save") }
-
-            Spacer(Modifier.height(8.dp))
-            Text("Enabled event types (CSV)", style = MaterialTheme.typography.titleMedium)
-            OutlinedTextField(
-                value = enabledTypesCsv,
-                onValueChange = onLocalEnabledTypesChange,
-                modifier = Modifier.fillMaxWidth()
-            )
-            Button(onClick = { onSaveEnabledTypes(enabledTypesCsv) }) { Text("Save") }
+            Button(
+                onClick = {
+                    onSaveQuietHours(
+                        quietStart.ifBlank { null },
+                        quietEnd.ifBlank { null }
+                    )
+                }
+            ) { Text("Save") }
         }
+
+        Row {
+            Checkbox(
+                checked = speakScreenOff,
+                onCheckedChange = { onSpeakScreenOffChange(it) }
+            )
+            Text("Speak only when screen is OFF", modifier = Modifier.padding(start = 8.dp))
+        }
+
+        Spacer(Modifier.height(8.dp))
+        Text(
+            "Disabled apps (CSV of package names)",
+            style = MaterialTheme.typography.titleMedium
+        )
+        OutlinedTextField(
+            value = disabledAppsCsv,
+            onValueChange = onLocalDisabledAppsChange,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Button(onClick = { onSaveDisabledApps(disabledAppsCsv) }) { Text("Save") }
+
+        Spacer(Modifier.height(8.dp))
+        Text("Enabled event types (CSV)", style = MaterialTheme.typography.titleMedium)
+        OutlinedTextField(
+            value = enabledTypesCsv,
+            onValueChange = onLocalEnabledTypesChange,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Button(onClick = { onSaveEnabledTypes(enabledTypesCsv) }) { Text("Save") }
     }
 }
 
 /** Compose Preview — no DataStore or ViewModel required */
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
+@OptIn(ExperimentalMaterial3Api::class)
 private fun SettingsContent_Preview() {
     // Preview uses local state to exercise the UI
     var quietStart by remember { mutableStateOf("22:00") }
@@ -155,20 +162,23 @@ private fun SettingsContent_Preview() {
     var speakScreenOff by remember { mutableStateOf(false) }
 
     MaterialTheme {
-        SettingsContent(
-            quietStart = quietStart,
-            quietEnd = quietEnd,
-            disabledAppsCsv = disabledAppsCsv,
-            enabledTypesCsv = enabledTypesCsv,
-            speakScreenOff = speakScreenOff,
-            onSaveQuietHours = { _, _ -> /* no-op in preview */ },
-            onSpeakScreenOffChange = { speakScreenOff = it },
-            onSaveDisabledApps = { /* no-op in preview */ },
-            onSaveEnabledTypes = { /* no-op in preview */ },
-            onLocalQuietStartChange = { quietStart = it },
-            onLocalQuietEndChange = { quietEnd = it },
-            onLocalDisabledAppsChange = { disabledAppsCsv = it },
-            onLocalEnabledTypesChange = { enabledTypesCsv = it },
-        )
+        Scaffold(topBar = { TopAppBar(title = { Text("Alfred Settings") }) }) { padding ->
+            SettingsContent(
+                quietStart = quietStart,
+                quietEnd = quietEnd,
+                disabledAppsCsv = disabledAppsCsv,
+                enabledTypesCsv = enabledTypesCsv,
+                speakScreenOff = speakScreenOff,
+                onSaveQuietHours = { _, _ -> /* no-op in preview */ },
+                onSpeakScreenOffChange = { speakScreenOff = it },
+                onSaveDisabledApps = { /* no-op in preview */ },
+                onSaveEnabledTypes = { /* no-op in preview */ },
+                onLocalQuietStartChange = { quietStart = it },
+                onLocalQuietEndChange = { quietEnd = it },
+                onLocalDisabledAppsChange = { disabledAppsCsv = it },
+                onLocalEnabledTypesChange = { enabledTypesCsv = it },
+                contentPadding = padding,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/swooby/alfred/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/swooby/alfred/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -162,7 +163,18 @@ private fun SettingsContent_Preview() {
     var speakScreenOff by remember { mutableStateOf(false) }
 
     MaterialTheme {
-        Scaffold(topBar = { TopAppBar(title = { Text("Alfred Settings") }) }) { padding ->
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Alfred Settings") },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                )
+            },
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ) { padding ->
             SettingsContent(
                 quietStart = quietStart,
                 quietEnd = quietEnd,

--- a/app/src/main/java/com/swooby/alfred/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/swooby/alfred/settings/SettingsScreen.kt
@@ -152,8 +152,8 @@ fun SettingsContent(
 
 /** Compose Preview — no DataStore or ViewModel required */
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
-@Composable
 @OptIn(ExperimentalMaterial3Api::class)
+@Composable
 private fun SettingsContent_Preview() {
     // Preview uses local state to exercise the UI
     var quietStart by remember { mutableStateOf("22:00") }

--- a/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
@@ -14,13 +14,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.core.view.WindowCompat
 import com.swooby.alfred.AlfredApp
 import com.swooby.alfred.pipeline.PipelineService
 import com.swooby.alfred.settings.SettingsScreen
@@ -38,23 +41,34 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             MaterialTheme {
+                val colorScheme = MaterialTheme.colorScheme
+
+                SideEffect {
+                    window.statusBarColor = colorScheme.primary.toArgb()
+                    WindowCompat
+                        .getInsetsController(window, window.decorView)
+                        ?.isAppearanceLightStatusBars = false
+                }
+
                 Scaffold(
                     topBar = {
                         TopAppBar(
                             title = { Text(text = stringResource(R.string.main_top_app_bar_title)) },
                             colors = TopAppBarDefaults.topAppBarColors(
-                                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                                containerColor = colorScheme.primary,
+                                titleContentColor = colorScheme.onPrimary,
+                                navigationIconContentColor = colorScheme.onPrimary,
+                                actionIconContentColor = colorScheme.onPrimary
                             )
                         )
                     },
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    containerColor = colorScheme.surfaceVariant
                 ) { innerPadding ->
                     Surface(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(innerPadding),
-                        color = MaterialTheme.colorScheme.surfaceVariant
+                        color = colorScheme.surfaceVariant
                     ) {
                         val ctx = LocalContext.current
 

--- a/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -39,13 +40,21 @@ class MainActivity : ComponentActivity() {
             MaterialTheme {
                 Scaffold(
                     topBar = {
-                        TopAppBar(title = { Text(text = stringResource(R.string.main_top_app_bar_title)) })
-                    }
+                        TopAppBar(
+                            title = { Text(text = stringResource(R.string.main_top_app_bar_title)) },
+                            colors = TopAppBarDefaults.topAppBarColors(
+                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        )
+                    },
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
                 ) { innerPadding ->
                     Surface(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(innerPadding)
+                            .padding(innerPadding),
+                        color = MaterialTheme.colorScheme.surfaceVariant
                     ) {
                         val ctx = LocalContext.current
 

--- a/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
@@ -4,14 +4,22 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import com.swooby.alfred.AlfredApp
 import com.swooby.alfred.pipeline.PipelineService
 import com.swooby.alfred.settings.SettingsScreen
@@ -19,35 +27,47 @@ import com.swooby.alfred.sources.NotifSvc
 import com.swooby.alfred.ui.permissions.PermissionsScreen
 import com.swooby.alfred.util.hasNotificationListenerAccess
 import com.swooby.alfred.util.isNotificationPermissionGranted
+import com.swooby.alfred.R
 
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val app = application as AlfredApp
 
         setContent {
             MaterialTheme {
-                Surface {
-                    val ctx = LocalContext.current
-
-                    var essentialsGranted by remember {
-                        mutableStateOf(
-                            isNotificationPermissionGranted(ctx) &&
-                                    hasNotificationListenerAccess(ctx, NotifSvc::class.java)
-                        )
+                Scaffold(
+                    topBar = {
+                        TopAppBar(title = { Text(text = stringResource(R.string.main_top_app_bar_title)) })
                     }
-                    // Auto-start service when essentials are granted
-                    if (essentialsGranted) {
-                        LaunchedEffect(Unit) {
-                            startForegroundService(Intent(this@MainActivity, PipelineService::class.java))
+                ) { innerPadding ->
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                    ) {
+                        val ctx = LocalContext.current
+
+                        var essentialsGranted by remember {
+                            mutableStateOf(
+                                isNotificationPermissionGranted(ctx) &&
+                                        hasNotificationListenerAccess(ctx, NotifSvc::class.java)
+                            )
                         }
-                        SettingsScreen(app)
-                    } else {
-                        PermissionsScreen(
-                            onEssentialsGranted = {
-                                essentialsGranted = true
+                        // Auto-start service when essentials are granted
+                        if (essentialsGranted) {
+                            LaunchedEffect(Unit) {
+                                startForegroundService(Intent(this@MainActivity, PipelineService::class.java))
                             }
-                        )
+                            SettingsScreen(app, modifier = Modifier.fillMaxSize())
+                        } else {
+                            PermissionsScreen(
+                                onEssentialsGranted = {
+                                    essentialsGranted = true
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
@@ -47,7 +47,7 @@ class MainActivity : ComponentActivity() {
                     window.statusBarColor = colorScheme.primary.toArgb()
                     WindowCompat
                         .getInsetsController(window, window.decorView)
-                        ?.isAppearanceLightStatusBars = false
+                        .isAppearanceLightStatusBars = false
                 }
 
                 Scaffold(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Alfred 2025</string>
+    <string name="main_top_app_bar_title">Alfred</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Alfred 2025</string>
-    <string name="main_top_app_bar_title">Alfred</string>
+    <string name="main_top_app_bar_title">Alfred 2025</string>
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- wrap MainActivity content in a Material 3 Scaffold and add a top app bar title
- expose padding/modifier hooks in SettingsScreen so it can live inside the activity scaffold without double bars
- add a dedicated string resource for the main screen title

## Testing
- ⚠️ `./gradlew :app:assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68dd1f1652948333939fd2a8bb212e25