### PR TITLE
chore: bump Gradle wrapper to 9.1.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- update the Gradle wrapper distribution to version 9.1.0

## Testing
- not run (unable to download Gradle distributions in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd1f42c3a48333a3275bd297414d04