### PR TITLE
Move hard-coded strings to Android resources

### DIFF
--- a/app/src/main/java/com/swooby/alfred/pipeline/PipelineService.kt
+++ b/app/src/main/java/com/swooby/alfred/pipeline/PipelineService.kt
@@ -11,6 +11,7 @@ import android.os.IBinder
 import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import com.swooby.alfred.AlfredApp
+import com.swooby.alfred.R
 import com.swooby.alfred.core.rules.Decision
 import com.swooby.alfred.core.rules.DeviceState
 import com.swooby.alfred.core.rules.RulesConfig
@@ -93,12 +94,16 @@ class PipelineService : Service() {
         val chId = "alfred_pipeline"
         val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         nm.createNotificationChannel(
-            NotificationChannel(chId, "Alfred", NotificationManager.IMPORTANCE_LOW)
+            NotificationChannel(
+                chId,
+                getString(R.string.pipeline_notification_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+            )
         )
 
         val builder = NotificationCompat.Builder(this, chId)
             .setSmallIcon(android.R.drawable.stat_notify_more)
-            .setContentTitle("Alfred is listening")
+            .setContentTitle(getString(R.string.pipeline_notification_title))
             .setOngoing(true)
 
         if (promptEnable) {
@@ -108,8 +113,8 @@ class PipelineService : Service() {
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
             builder
-                .setContentText("Enable Notification access for media tracking")
-                .addAction(0, "Enable", pi)
+                .setContentText(getString(R.string.pipeline_notification_permission))
+                .addAction(0, getString(R.string.pipeline_notification_action_enable), pi)
         }
 
         return builder.build()

--- a/app/src/main/java/com/swooby/alfred/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/swooby/alfred/settings/SettingsScreen.kt
@@ -23,9 +23,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.swooby.alfred.AlfredApp
+import com.swooby.alfred.R
 
 @Composable
 fun SettingsScreen(app: AlfredApp) {
@@ -78,7 +80,7 @@ fun SettingsContent(
     onLocalDisabledAppsChange: (String) -> Unit,
     onLocalEnabledTypesChange: (String) -> Unit,
 ) {
-    Scaffold(topBar = { TopAppBar(title = { Text("Alfred Settings") }) }) { pad ->
+    Scaffold(topBar = { TopAppBar(title = { Text(stringResource(id = R.string.settings_title)) }) }) { pad ->
         Column(
             Modifier
                 .padding(pad)
@@ -87,18 +89,21 @@ fun SettingsContent(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
 
-            Text("Quiet Hours (HH:mm)", style = MaterialTheme.typography.titleMedium)
+            Text(
+                stringResource(id = R.string.settings_quiet_hours_label),
+                style = MaterialTheme.typography.titleMedium
+            )
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedTextField(
                     value = quietStart,
                     onValueChange = onLocalQuietStartChange,
-                    label = { Text("Start e.g. 22:00") },
+                    label = { Text(stringResource(id = R.string.settings_quiet_hours_start_label)) },
                     modifier = Modifier.weight(1f)
                 )
                 OutlinedTextField(
                     value = quietEnd,
                     onValueChange = onLocalQuietEndChange,
-                    label = { Text("End e.g. 07:00") },
+                    label = { Text(stringResource(id = R.string.settings_quiet_hours_end_label)) },
                     modifier = Modifier.weight(1f)
                 )
                 Button(
@@ -108,7 +113,7 @@ fun SettingsContent(
                             quietEnd.ifBlank { null }
                         )
                     }
-                ) { Text("Save") }
+                ) { Text(stringResource(id = R.string.settings_save)) }
             }
 
             Row {
@@ -116,12 +121,15 @@ fun SettingsContent(
                     checked = speakScreenOff,
                     onCheckedChange = { onSpeakScreenOffChange(it) }
                 )
-                Text("Speak only when screen is OFF", modifier = Modifier.padding(start = 8.dp))
+                Text(
+                    stringResource(id = R.string.settings_speak_screen_off),
+                    modifier = Modifier.padding(start = 8.dp)
+                )
             }
 
             Spacer(Modifier.height(8.dp))
             Text(
-                "Disabled apps (CSV of package names)",
+                stringResource(id = R.string.settings_disabled_apps_label),
                 style = MaterialTheme.typography.titleMedium
             )
             OutlinedTextField(
@@ -129,16 +137,23 @@ fun SettingsContent(
                 onValueChange = onLocalDisabledAppsChange,
                 modifier = Modifier.fillMaxWidth()
             )
-            Button(onClick = { onSaveDisabledApps(disabledAppsCsv) }) { Text("Save") }
+            Button(onClick = { onSaveDisabledApps(disabledAppsCsv) }) {
+                Text(stringResource(id = R.string.settings_save))
+            }
 
             Spacer(Modifier.height(8.dp))
-            Text("Enabled event types (CSV)", style = MaterialTheme.typography.titleMedium)
+            Text(
+                stringResource(id = R.string.settings_enabled_event_types_label),
+                style = MaterialTheme.typography.titleMedium
+            )
             OutlinedTextField(
                 value = enabledTypesCsv,
                 onValueChange = onLocalEnabledTypesChange,
                 modifier = Modifier.fillMaxWidth()
             )
-            Button(onClick = { onSaveEnabledTypes(enabledTypesCsv) }) { Text("Save") }
+            Button(onClick = { onSaveEnabledTypes(enabledTypesCsv) }) {
+                Text(stringResource(id = R.string.settings_save))
+            }
         }
     }
 }

--- a/app/src/main/java/com/swooby/alfred/ui/permissions/PermissionsScreen.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/permissions/PermissionsScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import com.swooby.alfred.R
 import com.swooby.alfred.sources.NotifSvc
 import com.swooby.alfred.util.*
 
@@ -88,16 +90,20 @@ fun PermissionsScreen(
             .padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Text(
-            "Alfred 2025 Setup",
+            stringResource(R.string.permissions_title_setup),
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold
         )
 
         PermissionCard(
-            title = "Post Notifications",
-            description = "Lets Alfred 2025 speak and show status; required on Android 13+.",
+            title = stringResource(R.string.permissions_post_notifications_title),
+            description = stringResource(R.string.permissions_post_notifications_description),
             granted = notifGranted,
-            actionLabel = if (Build.VERSION.SDK_INT >= 33) "Grant" else "Open Settings",
+            actionLabel = if (Build.VERSION.SDK_INT >= 33) {
+                stringResource(R.string.permissions_action_grant)
+            } else {
+                stringResource(R.string.permissions_action_open_settings)
+            },
             onClick = {
                 if (Build.VERSION.SDK_INT >= 33) {
                     notifPermLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
@@ -108,18 +114,18 @@ fun PermissionsScreen(
         )
 
         PermissionCard(
-            title = "Notification Listener Access",
-            description = "Allows Alfred 2025 to read media sessions and notifications for smarter announcements.",
+            title = stringResource(R.string.permissions_notification_listener_title),
+            description = stringResource(R.string.permissions_notification_listener_description),
             granted = listenerGranted,
-            actionLabel = "Open Settings",
+            actionLabel = stringResource(R.string.permissions_action_open_settings),
             onClick = { ctx.startActivity(intentOpenNotificationListenerSettings()) }
         )
 
         PermissionCard(
-            title = "Ignore Battery Optimizations",
-            description = "Keeps Alfred 2025 responsive in the background. Recommended.",
+            title = stringResource(R.string.permissions_ignore_battery_title),
+            description = stringResource(R.string.permissions_ignore_battery_description),
             granted = ignoringDoze,
-            actionLabel = "Allow",
+            actionLabel = stringResource(R.string.permissions_action_allow),
             onClick = { ctx.startActivity(intentRequestIgnoreBatteryOptimizations(ctx)) },
             optional = true
         )
@@ -129,7 +135,15 @@ fun PermissionsScreen(
             enabled = essentialsGranted,
             onClick = onEssentialsGranted,
             modifier = Modifier.align(Alignment.End)
-        ) { Text(if (essentialsGranted) "Start Alfred 2025" else "Complete required steps") }
+        ) {
+            Text(
+                if (essentialsGranted) {
+                    stringResource(R.string.permissions_start_button)
+                } else {
+                    stringResource(R.string.permissions_complete_steps)
+                }
+            )
+        }
     }
 }
 
@@ -151,15 +165,18 @@ private fun PermissionCard(
                     modifier = Modifier.weight(1f)
                 )
                 val status = when {
-                    granted -> "Granted"
-                    optional -> "Optional"
-                    else -> "Missing"
+                    granted -> stringResource(R.string.permissions_status_granted)
+                    optional -> stringResource(R.string.permissions_status_optional)
+                    else -> stringResource(R.string.permissions_status_missing)
                 }
                 AssistChip(onClick = {}, label = { Text(status) }, enabled = false)
             }
             Text(
-                if (optional) "$description (This is optional; Alfred 2025 works without it.)"
-                else description,
+                if (optional) {
+                    stringResource(R.string.permissions_optional_description, description)
+                } else {
+                    description
+                },
                 style = MaterialTheme.typography.bodyMedium
             )
             Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Alfred 2025</string>
+    <string name="settings_title">Alfred Settings</string>
+    <string name="settings_quiet_hours_label">Quiet Hours (HH:mm)</string>
+    <string name="settings_quiet_hours_start_label">Start e.g. 22:00</string>
+    <string name="settings_quiet_hours_end_label">End e.g. 07:00</string>
+    <string name="settings_save">Save</string>
+    <string name="settings_speak_screen_off">Speak only when screen is OFF</string>
+    <string name="settings_disabled_apps_label">Disabled apps (CSV of package names)</string>
+    <string name="settings_enabled_event_types_label">Enabled event types (CSV)</string>
+    <string name="pipeline_notification_channel_name">Alfred</string>
+    <string name="pipeline_notification_title">Alfred is listening</string>
+    <string name="pipeline_notification_permission">Enable Notification access for media tracking</string>
+    <string name="pipeline_notification_action_enable">Enable</string>
+    <string name="permissions_title_setup">Alfred 2025 Setup</string>
+    <string name="permissions_post_notifications_title">Post Notifications</string>
+    <string name="permissions_post_notifications_description">Lets Alfred 2025 speak and show status; required on Android 13+.</string>
+    <string name="permissions_action_grant">Grant</string>
+    <string name="permissions_action_open_settings">Open Settings</string>
+    <string name="permissions_notification_listener_title">Notification Listener Access</string>
+    <string name="permissions_notification_listener_description">Allows Alfred 2025 to read media sessions and notifications for smarter announcements.</string>
+    <string name="permissions_ignore_battery_title">Ignore Battery Optimizations</string>
+    <string name="permissions_ignore_battery_description">Keeps Alfred 2025 responsive in the background. Recommended.</string>
+    <string name="permissions_action_allow">Allow</string>
+    <string name="permissions_start_button">Start Alfred 2025</string>
+    <string name="permissions_complete_steps">Complete required steps</string>
+    <string name="permissions_status_granted">Granted</string>
+    <string name="permissions_status_optional">Optional</string>
+    <string name="permissions_status_missing">Missing</string>
+    <string name="permissions_optional_description">%1$s (This is optional; Alfred 2025 works without it.)</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace hard-coded Settings UI labels with string resources
- externalize pipeline notification text into resources for localization
- move Permissions screen user-facing strings into Android string resources, including optional note messaging

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Gradle distribution download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1f4de60c833391690553abcecc3b