### PR TITLE
Gate release APK build to main

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -38,8 +38,12 @@ jobs:
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
-      - name: Build debug and release APKs
-        run: ./gradlew assembleDebug assembleRelease
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Build release APK
+        if: github.ref == 'refs/heads/main'
+        run: ./gradlew assembleRelease
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
@@ -48,6 +52,7 @@ jobs:
           path: app/build/outputs/apk/debug/*.apk
 
       - name: Upload release APK
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: app-release-apk


### PR DESCRIPTION
## Summary
- split the Gradle build into separate debug and release steps
- guard release build and artifact upload so they only run on main branch pushes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dffeb3660883339f96ac3d79d14ca1