### PR TITLE
Cache Android SDK during GitHub Actions builds

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -28,7 +28,15 @@ jobs:
           packages: |-
             platform-tools
 
+      - name: Cache Android SDK
+        id: cache-android-sdk
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.ANDROID_SDK_ROOT }}
+          key: android-sdk-${{ runner.os }}-android-36-36.0.0-rc1
+
       - name: Install preview SDK components
+        if: steps.cache-android-sdk.outputs.cache-hit != 'true'
         run: |
           yes | sdkmanager --licenses
           yes | sdkmanager --channel=3 "platforms;android-36" "build-tools;36.0.0-rc1"


### PR DESCRIPTION
## Summary
- cache the configured Android SDK directory in the CI workflow to reuse downloads
- skip the preview SDK installation step when the cache is hit to avoid redundant sdkmanager runs

## Testing
- not run (CI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dffed131148333be25089b7b9119f6