### PR TITLE
Narrow Android SDK cache to preview artifacts

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PREVIEW_API_LEVEL: 36
+      PREVIEW_BUILD_TOOLS: 36.0.0-rc1
 
     steps:
       - name: Check out repository
@@ -28,10 +31,21 @@ jobs:
           packages: |-
             platform-tools
 
+      - name: Cache Android SDK
+        id: cache-android-sdk
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.ANDROID_SDK_ROOT }}/platforms/android-${{ env.PREVIEW_API_LEVEL }}
+            ${{ env.ANDROID_SDK_ROOT }}/build-tools/${{ env.PREVIEW_BUILD_TOOLS }}
+            ${{ env.ANDROID_SDK_ROOT }}/licenses
+          key: android-sdk-preview-${{ runner.os }}-${{ env.PREVIEW_API_LEVEL }}-${{ env.PREVIEW_BUILD_TOOLS }}
+
       - name: Install preview SDK components
+        if: steps.cache-android-sdk.outputs.cache-hit != 'true'
         run: |
           yes | sdkmanager --licenses
-          yes | sdkmanager --channel=3 "platforms;android-36" "build-tools;36.0.0-rc1"
+          yes | sdkmanager --channel=3 "platforms;android-${{ env.PREVIEW_API_LEVEL }}" "build-tools;${{ env.PREVIEW_BUILD_TOOLS }}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -31,9 +31,9 @@ jobs:
           packages: |-
             platform-tools
 
-      - name: Cache Android SDK
-        id: cache-android-sdk
-        uses: actions/cache@v4
+      - name: Restore Android SDK cache
+        id: restore-android-sdk
+        uses: actions/cache/restore@v4
         with:
           path: |
             ${{ env.ANDROID_SDK_ROOT }}/platforms/android-${{ env.PREVIEW_API_LEVEL }}
@@ -42,10 +42,20 @@ jobs:
           key: android-sdk-preview-${{ runner.os }}-${{ env.PREVIEW_API_LEVEL }}-${{ env.PREVIEW_BUILD_TOOLS }}
 
       - name: Install preview SDK components
-        if: steps.cache-android-sdk.outputs.cache-hit != 'true'
+        if: steps.restore-android-sdk.outputs.cache-hit != 'true'
         run: |
           yes | sdkmanager --licenses
           yes | sdkmanager --channel=3 "platforms;android-${{ env.PREVIEW_API_LEVEL }}" "build-tools;${{ env.PREVIEW_BUILD_TOOLS }}"
+
+      - name: Save Android SDK cache
+        if: steps.restore-android-sdk.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.ANDROID_SDK_ROOT }}/platforms/android-${{ env.PREVIEW_API_LEVEL }}
+            ${{ env.ANDROID_SDK_ROOT }}/build-tools/${{ env.PREVIEW_BUILD_TOOLS }}
+            ${{ env.ANDROID_SDK_ROOT }}/licenses
+          key: android-sdk-preview-${{ runner.os }}-${{ env.PREVIEW_API_LEVEL }}-${{ env.PREVIEW_BUILD_TOOLS }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,13 +24,6 @@ jobs:
           java-version: '21'
           cache: gradle
 
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-        with:
-          cmdline-tools-version: latest
-          packages: |-
-            platform-tools
-
       - name: Restore Android SDK cache
         id: restore-android-sdk
         uses: actions/cache/restore@v4
@@ -40,6 +33,14 @@ jobs:
             ${{ env.ANDROID_SDK_ROOT }}/build-tools/${{ env.PREVIEW_BUILD_TOOLS }}
             ${{ env.ANDROID_SDK_ROOT }}/licenses
           key: android-sdk-preview-${{ runner.os }}-${{ env.PREVIEW_API_LEVEL }}-${{ env.PREVIEW_BUILD_TOOLS }}
+
+      - name: Set up Android SDK
+        if: steps.restore-android-sdk.outputs.cache-hit != 'true'
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: latest
+          packages: |-
+            platform-tools
 
       - name: Install preview SDK components
         if: steps.restore-android-sdk.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- scope the Android SDK cache to only the preview platform, build tools, and license directories
- keep the preview SDK installation step conditional on cache misses to refresh directories when needed

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e007813f588333833d5aef6572df98