### PR TITLE
Add Compose event timeline activity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     debugImplementation(libs.androidx.compose.ui.tooling)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,10 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".ui.events.EventListActivity"
+            android:exported="false" />
+
         <service
             android:name=".pipeline.PipelineService"
             android:exported="false"

--- a/app/src/main/java/com/swooby/alfred/ui/events/EventListActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/events/EventListActivity.kt
@@ -1,0 +1,58 @@
+package com.swooby.alfred.ui.events
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.core.view.WindowCompat
+import com.swooby.alfred.AlfredApp
+import com.swooby.alfred.ui.MainActivity
+
+class EventListActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        val app = application as AlfredApp
+        val userId = intent.getStringExtra(EXTRA_USER_ID) ?: DEFAULT_USER_ID
+        val viewModelFactory = EventListViewModel.Factory(app.db.events(), userId)
+        val initials = userId.firstOrNull()?.uppercaseChar()?.toString() ?: "U"
+
+        setContent {
+            MaterialTheme {
+                SideEffect {
+                    window.statusBarColor = Color.Transparent.toArgb()
+                    WindowCompat
+                        .getInsetsController(window, window.decorView)
+                        .isAppearanceLightStatusBars = false
+                }
+
+                val viewModel: EventListViewModel = viewModel(factory = viewModelFactory)
+                val uiState by viewModel.state.collectAsState()
+
+                EventListScreen(
+                    state = uiState,
+                    userInitials = initials,
+                    onQueryChange = viewModel::onQueryChange,
+                    onRefresh = viewModel::refresh,
+                    onNavigateToSettings = {
+                        startActivity(Intent(this, MainActivity::class.java))
+                    }
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val EXTRA_USER_ID: String = "event_list_extra_user_id"
+        private const val DEFAULT_USER_ID: String = "u_local"
+    }
+}

--- a/app/src/main/java/com/swooby/alfred/ui/events/EventListScreen.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/events/EventListScreen.kt
@@ -1,0 +1,552 @@
+package com.swooby.alfred.ui.events
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.swooby.alfred.R
+import com.swooby.alfred.data.EventEntity
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.time.Instant
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventListScreen(
+    state: EventListUiState,
+    userInitials: String,
+    onQueryChange: (String) -> Unit,
+    onRefresh: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val drawerState: DrawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(state.errorMessage) {
+        val message = state.errorMessage
+        if (!message.isNullOrBlank()) {
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            ModalDrawerSheet {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .statusBarsPadding()
+                        .padding(vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = LocalizedStrings.drawerTitle,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(horizontal = 24.dp)
+                    )
+                    NavigationDrawerItem(
+                        label = { Text(text = LocalizedStrings.drawerSettings) },
+                        selected = false,
+                        onClick = {
+                            coroutineScope.launch {
+                                drawerState.close()
+                                onNavigateToSettings()
+                            }
+                        },
+                        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                    )
+                }
+            }
+        },
+        modifier = modifier,
+        scrimColor = MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f)
+    ) {
+        EventListScaffold(
+            state = state,
+            userInitials = userInitials,
+            snackbarHostState = snackbarHostState,
+            onQueryChange = onQueryChange,
+            onRefresh = onRefresh,
+            onMenuClick = {
+                coroutineScope.launch { drawerState.open() }
+            },
+            onAvatarClick = {
+                coroutineScope.launch { drawerState.open() }
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EventListScaffold(
+    state: EventListUiState,
+    userInitials: String,
+    snackbarHostState: SnackbarHostState,
+    onQueryChange: (String) -> Unit,
+    onRefresh: () -> Unit,
+    onMenuClick: () -> Unit,
+    onAvatarClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = colorScheme.surface,
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(colorScheme.surface)
+                .padding(innerPadding)
+        ) {
+            EventListTopBar(
+                query = state.query,
+                isRefreshing = state.isLoading,
+                userInitials = userInitials,
+                lastUpdated = state.lastUpdated,
+                onQueryChange = onQueryChange,
+                onRefresh = onRefresh,
+                onMenuClick = onMenuClick,
+                onAvatarClick = onAvatarClick,
+            )
+
+            AnimatedVisibility(
+                visible = state.isLoading,
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                LinearProgressIndicator(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            EventListContent(
+                state = state,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f, fill = true)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EventListTopBar(
+    query: String,
+    isRefreshing: Boolean,
+    userInitials: String,
+    lastUpdated: Instant?,
+    onQueryChange: (String) -> Unit,
+    onRefresh: () -> Unit,
+    onMenuClick: () -> Unit,
+    onAvatarClick: () -> Unit,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = colorScheme.surface,
+        tonalElevation = 6.dp,
+        shadowElevation = 4.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onMenuClick) {
+                    Icon(
+                        imageVector = Icons.Outlined.Menu,
+                        contentDescription = LocalizedStrings.menuContentDescription,
+                        tint = colorScheme.onSurface
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                Avatar(initials = userInitials, onClick = onAvatarClick)
+            }
+
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(28.dp),
+                placeholder = { Text(text = LocalizedStrings.searchPlaceholder) },
+                singleLine = true,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Search,
+                        contentDescription = null
+                    )
+                },
+                trailingIcon = {
+                    if (isRefreshing) {
+                        androidx.compose.material3.CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        IconButton(onClick = onRefresh) {
+                            Icon(
+                                imageVector = Icons.Outlined.Refresh,
+                                contentDescription = LocalizedStrings.refreshContentDescription
+                            )
+                        }
+                    }
+                },
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedContainerColor = colorScheme.surfaceContainer,
+                    unfocusedContainerColor = colorScheme.surfaceContainerHigh,
+                    focusedBorderColor = Color.Transparent,
+                    unfocusedBorderColor = Color.Transparent,
+                    cursorColor = colorScheme.primary
+                )
+            )
+
+            lastUpdated?.let { instant ->
+                AssistChip(
+                    onClick = {},
+                    enabled = false,
+                    label = { Text(text = LocalizedStrings.lastUpdatedLabel(formatInstant(instant))) },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = colorScheme.surfaceContainerHigh,
+                        labelColor = colorScheme.onSurfaceVariant,
+                        disabledContainerColor = colorScheme.surfaceContainerHigh,
+                        disabledLabelColor = colorScheme.onSurfaceVariant
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Avatar(initials: String, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .semantics { contentDescription = LocalizedStrings.avatarContentDescription },
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primaryContainer,
+        onClick = onClick,
+    ) {
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Text(
+                text = initials,
+                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold)
+            )
+        }
+    }
+}
+
+@Composable
+private fun EventListContent(state: EventListUiState, modifier: Modifier = Modifier) {
+    if (state.visibleEvents.isEmpty()) {
+        EmptyState(modifier = modifier.fillMaxSize())
+        return
+    }
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .navigationBarsPadding(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 12.dp)
+    ) {
+        item {
+            Text(
+                text = LocalizedStrings.recentSection,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+            )
+        }
+
+        items(state.visibleEvents) { event ->
+            EventRow(event = event)
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 32.dp)
+            .navigationBarsPadding(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = LocalizedStrings.emptyTitle,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = LocalizedStrings.emptyBody,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun EventRow(event: EventEntity, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shape = RoundedCornerShape(24.dp),
+        tonalElevation = 3.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = event.subjectEntity,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (!event.eventAction.isBlank()) {
+                    Text(
+                        text = event.eventAction,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = event.eventCategory,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = formatInstant(event.tsStart),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (event.tags.isNotEmpty()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    event.tags.take(3).forEach { tag ->
+                        AssistChip(
+                            onClick = {},
+                            label = { Text(text = tag) },
+                            colors = AssistChipDefaults.assistChipColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                labelColor = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                        )
+                    }
+                }
+            }
+
+            Divider(color = MaterialTheme.colorScheme.surfaceVariant)
+
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = LocalizedStrings.eventTypeLabel(event.eventType),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                event.subjectEntityId?.let {
+                    Text(
+                        text = LocalizedStrings.entityIdLabel(it),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+private object LocalizedStrings {
+    val drawerTitle: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_drawer_title)
+
+    val drawerSettings: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_drawer_settings)
+
+    val menuContentDescription: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_menu_cd)
+
+    val refreshContentDescription: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_refresh_cd)
+
+    val searchPlaceholder: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_search_placeholder)
+
+    val recentSection: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_recent_section)
+
+    val emptyTitle: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_empty_title)
+
+    val emptyBody: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_empty_body)
+
+    val lastUpdatedLabel: (String) -> String
+        @Composable get() = { value -> stringResourceWrapper(R.string.event_list_last_updated, value) }
+
+    val avatarContentDescription: String
+        @Composable get() = stringResourceWrapper(R.string.event_list_avatar_cd)
+
+    @Composable
+    fun eventTypeLabel(eventType: String): String =
+        stringResourceWrapper(R.string.event_list_event_type, eventType)
+
+    @Composable
+    fun entityIdLabel(id: String): String =
+        stringResourceWrapper(R.string.event_list_entity_id, id)
+}
+
+@Composable
+private fun stringResourceWrapper(id: Int, vararg args: Any): String {
+    return androidx.compose.ui.res.stringResource(id = id, *args)
+}
+
+private val TIME_FORMATTER: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("MMM d, yyyy · h:mm a", Locale.getDefault())
+
+private fun formatInstant(instant: Instant): String {
+    val zonedDateTime = java.time.Instant.ofEpochMilli(instant.toEpochMilliseconds())
+        .atZone(ZoneId.systemDefault())
+    return TIME_FORMATTER.format(zonedDateTime)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EventListPreview() {
+    val now = Instant.fromEpochMilliseconds(java.time.Instant.now().toEpochMilli())
+    val sampleEvents = listOf(
+        EventEntity(
+            eventId = "evt-1",
+            userId = "u_local",
+            deviceId = "pixel-9",
+            eventType = "notification",
+            eventCategory = "Inbox",
+            eventAction = "Received new message",
+            subjectEntity = "Email",
+            tsStart = now,
+            tags = listOf("priority", "gmail")
+        ),
+        EventEntity(
+            eventId = "evt-2",
+            userId = "u_local",
+            deviceId = "pixel-9",
+            eventType = "call",
+            eventCategory = "Communications",
+            eventAction = "Missed call",
+            subjectEntity = "Carol Micek",
+            tsStart = Instant.fromEpochMilliseconds(now.toEpochMilliseconds() - 3_600_000),
+            tags = listOf("work")
+        )
+    )
+
+    EventListScreen(
+        state = EventListUiState(
+            query = "",
+            allEvents = sampleEvents,
+            visibleEvents = sampleEvents
+        ),
+        userInitials = "A",
+        onQueryChange = {},
+        onRefresh = {},
+        onNavigateToSettings = {}
+    )
+}

--- a/app/src/main/java/com/swooby/alfred/ui/events/EventListViewModel.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/events/EventListViewModel.kt
@@ -1,0 +1,118 @@
+package com.swooby.alfred.ui.events
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.swooby.alfred.data.EventDao
+import com.swooby.alfred.data.EventEntity
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/**
+ * UI state container for the event list screen.
+ */
+data class EventListUiState(
+    val query: String = "",
+    val allEvents: List<EventEntity> = emptyList(),
+    val visibleEvents: List<EventEntity> = emptyList(),
+    val isLoading: Boolean = false,
+    val lastUpdated: Instant? = null,
+    val errorMessage: String? = null,
+)
+
+class EventListViewModel(
+    private val eventDao: EventDao,
+    private val userId: String,
+    private val lookback: Duration = 7.days,
+    private val limit: Int = 500,
+    private val clock: Clock = Clock.System,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(EventListUiState(isLoading = true))
+    val state: StateFlow<EventListUiState> = _state.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun onQueryChange(value: String) {
+        val normalized = value.take(200)
+        _state.update { current ->
+            val filtered = applyFilter(current.allEvents, normalized)
+            current.copy(query = normalized, visibleEvents = filtered)
+        }
+    }
+
+    fun refresh() {
+        viewModelScope.launch(Dispatchers.IO) {
+            _state.update { it.copy(isLoading = true, errorMessage = null) }
+            try {
+                val now = clock.now()
+                val fromEpochMillis = now.toEpochMilliseconds() - lookback.inWholeMilliseconds
+                val from = Instant.fromEpochMilliseconds(fromEpochMillis)
+                val events = eventDao.listByTime(userId, from, now, limit)
+                _state.update { current ->
+                    val filtered = applyFilter(events, current.query)
+                    current.copy(
+                        isLoading = false,
+                        allEvents = events,
+                        visibleEvents = filtered,
+                        lastUpdated = now,
+                        errorMessage = null,
+                    )
+                }
+            } catch (t: Throwable) {
+                _state.update { current ->
+                    current.copy(
+                        isLoading = false,
+                        errorMessage = t.message ?: t::class.simpleName ?: "error",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun applyFilter(events: List<EventEntity>, query: String): List<EventEntity> {
+        if (query.isBlank()) return events
+        val locale = Locale.getDefault()
+        val normalized = query.trim().lowercase(locale)
+        return events.filter { event ->
+            buildList {
+                add(event.eventType)
+                add(event.eventCategory)
+                add(event.eventAction)
+                add(event.subjectEntity)
+                event.subjectEntityId?.let(::add)
+                event.subjectParentId?.let(::add)
+                addAll(event.tags)
+            }.any { candidate ->
+                candidate.lowercase(locale).contains(normalized)
+            }
+        }
+    }
+
+    class Factory(
+        private val eventDao: EventDao,
+        private val userId: String,
+        private val lookback: Duration = 7.days,
+        private val limit: Int = 500,
+        private val clock: Clock = Clock.System,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(EventListViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return EventListViewModel(eventDao, userId, lookback, limit, clock) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class: ${'$'}modelClass")
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,17 @@
     <string name="permissions_status_optional">Optional</string>
     <string name="permissions_status_missing">Missing</string>
     <string name="permissions_optional_description">%1$s (This is optional; Alfred 2025 works without it.)</string>
+
+    <string name="event_list_drawer_title">Alfred</string>
+    <string name="event_list_drawer_settings">Settings</string>
+    <string name="event_list_menu_cd">Open navigation</string>
+    <string name="event_list_refresh_cd">Refresh timeline</string>
+    <string name="event_list_avatar_cd">Open account menu</string>
+    <string name="event_list_search_placeholder">Search events</string>
+    <string name="event_list_recent_section">Recent activity</string>
+    <string name="event_list_empty_title">Nothing to hear yet</string>
+    <string name="event_list_empty_body">When Alfred ingests new activity it will appear here automatically.</string>
+    <string name="event_list_last_updated">Updated %1$s</string>
+    <string name="event_list_event_type">Type: %1$s</string>
+    <string name="event_list_entity_id">Entity ID: %1$s</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ work = "2.10.5"
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended", version.ref = "composeBom" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeBom" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeBom" }
 #androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeBom" }


### PR DESCRIPTION
## Summary
- add a Compose-powered `EventListActivity` that renders `EventEntity` data using `EventDao.listByTime`
- implement a modern Material 3 timeline surface with search, navigation drawer, and avatar controls
- register the activity, add supporting strings, and pull in the material icons dependency

## Testing
- `./gradlew :app:assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e01095b9008333af702e8b18c84e51