### PR TITLE
Add theme mode selection to drawer

### DIFF
--- a/app/src/main/java/com/swooby/alfred/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/swooby/alfred/settings/SettingsRepository.kt
@@ -21,6 +21,7 @@ class SettingsRepository(private val app: Context) {
         val QUIET_END   = stringPreferencesKey("quiet_end")
         val DISABLED_APPS = stringPreferencesKey("disabled_apps_csv")
         val ENABLED_TYPES = stringPreferencesKey("enabled_types_csv")
+        val THEME_MODE = stringPreferencesKey("theme_mode")
     }
     private val defaultEnabled = setOf("media.start","media.stop","notif.post","display.on","display.off","network.wifi.connect","network.wifi.disconnect")
     val rulesConfigFlow: Flow<RulesConfig> =
@@ -33,10 +34,19 @@ class SettingsRepository(private val app: Context) {
             val enabledTypes = (p[K.ENABLED_TYPES] ?: defaultEnabled.joinToString(",")).split(',').mapNotNull { it.trim().ifEmpty { null } }.toSet()
             RulesConfig(enabledTypes, disabledApps, quiet, speakOff, listOf(RateLimit("media.start",30,4), RateLimit("notif.post",10,6)))
         }
+
+    val themeModeFlow: Flow<ThemeMode> =
+        app.settingsDataStore.data.map { preferences ->
+            ThemeMode.fromPreference(preferences[K.THEME_MODE])
+        }
+
     suspend fun setQuietHours(startHHmm: String?, endHHmm: String?) {
         app.settingsDataStore.edit { e -> e[K.QUIET_START] = startHHmm ?: ""; e[K.QUIET_END] = endHHmm ?: "" }
     }
     suspend fun setSpeakWhenScreenOffOnly(enabled: Boolean) { app.settingsDataStore.edit { it[K.SPEAK_SCREEN_OFF_ONLY] = enabled } }
     suspend fun setDisabledAppsCsv(csv: String) { app.settingsDataStore.edit { it[K.DISABLED_APPS] = csv } }
     suspend fun setEnabledTypesCsv(csv: String) { app.settingsDataStore.edit { it[K.ENABLED_TYPES] = csv } }
+    suspend fun setThemeMode(themeMode: ThemeMode) {
+        app.settingsDataStore.edit { it[K.THEME_MODE] = themeMode.asPreferenceString() }
+    }
 }

--- a/app/src/main/java/com/swooby/alfred/settings/ThemeMode.kt
+++ b/app/src/main/java/com/swooby/alfred/settings/ThemeMode.kt
@@ -1,0 +1,21 @@
+package com.swooby.alfred.settings
+
+import java.util.Locale
+
+/** Represents the theme preference selected by the user. */
+enum class ThemeMode(private val storageValue: String) {
+    SYSTEM("system"),
+    LIGHT("light"),
+    DARK("dark");
+
+    override fun toString(): String = storageValue
+
+    fun asPreferenceString(): String = storageValue
+
+    companion object {
+        fun fromPreference(value: String?): ThemeMode {
+            val normalized = value?.lowercase(Locale.ROOT)
+            return values().firstOrNull { it.storageValue == normalized } ?: SYSTEM
+        }
+    }
+}

--- a/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/MainActivity.kt
@@ -3,6 +3,7 @@ package com.swooby.alfred.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -13,6 +14,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.luminance
@@ -21,6 +24,7 @@ import androidx.core.view.WindowCompat
 import com.swooby.alfred.AlfredApp
 import com.swooby.alfred.R
 import com.swooby.alfred.settings.SettingsScreen
+import com.swooby.alfred.settings.ThemeMode
 import com.swooby.alfred.ui.theme.AlfredTheme
 
 class MainActivity : ComponentActivity() {
@@ -30,7 +34,14 @@ class MainActivity : ComponentActivity() {
         val app = application as AlfredApp
 
         setContent {
-            AlfredTheme {
+            val themeMode by app.settings.themeModeFlow.collectAsState(initial = ThemeMode.SYSTEM)
+            val darkTheme = when (themeMode) {
+                ThemeMode.SYSTEM -> isSystemInDarkTheme()
+                ThemeMode.DARK -> true
+                ThemeMode.LIGHT -> false
+            }
+
+            AlfredTheme(darkTheme = darkTheme) {
                 val colorScheme = MaterialTheme.colorScheme
                 val useLightStatusIcons = colorScheme.primary.luminance() > 0.5f
 

--- a/app/src/main/java/com/swooby/alfred/ui/events/EventListScreen.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/events/EventListScreen.kt
@@ -90,6 +90,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.swooby.alfred.R
 import com.swooby.alfred.data.EventEntity
+import com.swooby.alfred.settings.ThemeMode
 import com.swooby.alfred.ui.theme.AlfredTheme
 import kotlinx.coroutines.launch
 import java.time.ZoneId
@@ -101,6 +102,7 @@ import kotlin.time.Instant
 fun EventListScreen(
     state: EventListUiState,
     userInitials: String,
+    themeMode: ThemeMode,
     onQueryChange: (String) -> Unit,
     onRefresh: () -> Unit,
     onNavigateToSettings: () -> Unit,
@@ -109,6 +111,7 @@ fun EventListScreen(
     onSelectAll: () -> Unit,
     onUnselectAll: () -> Unit,
     onDeleteSelected: () -> Unit,
+    onThemeModeChange: (ThemeMode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val drawerState: DrawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -153,6 +156,10 @@ fun EventListScreen(
                         text = LocalizedStrings.drawerTitle,
                         style = MaterialTheme.typography.titleMedium,
                         modifier = Modifier.padding(horizontal = 24.dp)
+                    )
+                    DrawerThemeModeSection(
+                        selectedMode = themeMode,
+                        onThemeModeChange = onThemeModeChange
                     )
                     NavigationDrawerItem(
                         label = { Text(text = LocalizedStrings.drawerSettings) },
@@ -227,6 +234,35 @@ fun EventListScreen(
             inProgress = state.isPerformingAction
         )
     }
+}
+
+@Composable
+private fun DrawerThemeModeSection(
+    selectedMode: ThemeMode,
+    onThemeModeChange: (ThemeMode) -> Unit,
+) {
+    Spacer(modifier = Modifier.height(12.dp))
+    Text(
+        text = LocalizedStrings.drawerThemeModeTitle,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 24.dp)
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    ThemeMode.values().forEach { mode ->
+        val label = when (mode) {
+            ThemeMode.SYSTEM -> LocalizedStrings.themeModeSystem
+            ThemeMode.LIGHT -> LocalizedStrings.themeModeLight
+            ThemeMode.DARK -> LocalizedStrings.themeModeDark
+        }
+        NavigationDrawerItem(
+            label = { Text(text = label) },
+            selected = selectedMode == mode,
+            onClick = { onThemeModeChange(mode) },
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+        )
+    }
+    Spacer(modifier = Modifier.height(8.dp))
 }
 
 @Composable
@@ -1022,6 +1058,18 @@ private object LocalizedStrings {
     val drawerSettings: String
         @Composable get() = stringResource(R.string.event_list_drawer_settings)
 
+    val drawerThemeModeTitle: String
+        @Composable get() = stringResource(R.string.event_list_drawer_theme_mode_title)
+
+    val themeModeSystem: String
+        @Composable get() = stringResource(R.string.event_list_theme_mode_system)
+
+    val themeModeLight: String
+        @Composable get() = stringResource(R.string.event_list_theme_mode_light)
+
+    val themeModeDark: String
+        @Composable get() = stringResource(R.string.event_list_theme_mode_dark)
+
     val menuContentDescription: String
         @Composable get() = stringResource(R.string.event_list_menu_cd)
 
@@ -1141,6 +1189,7 @@ private fun EventListPreview() {
                 visibleEvents = sampleEvents
             ),
             userInitials = "A",
+            themeMode = ThemeMode.SYSTEM,
             onQueryChange = {},
             onRefresh = {},
             onNavigateToSettings = {},
@@ -1148,7 +1197,8 @@ private fun EventListPreview() {
             onEventSelectionChange = { _, _ -> },
             onSelectAll = {},
             onUnselectAll = {},
-            onDeleteSelected = {}
+            onDeleteSelected = {},
+            onThemeModeChange = {}
         )
     }
 }

--- a/app/src/main/java/com/swooby/alfred/ui/permissions/PermissionsActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/ui/permissions/PermissionsActivity.kt
@@ -4,18 +4,23 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.luminance
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
+import com.swooby.alfred.AlfredApp
 import com.swooby.alfred.pipeline.PipelineService
 import com.swooby.alfred.ui.events.EventListActivity
 import com.swooby.alfred.ui.theme.AlfredTheme
+import com.swooby.alfred.settings.ThemeMode
 
 class PermissionsActivity : ComponentActivity() {
 
@@ -23,9 +28,17 @@ class PermissionsActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        val app = application as AlfredApp
 
         setContent {
-            AlfredTheme {
+            val themeMode by app.settings.themeModeFlow.collectAsState(initial = ThemeMode.SYSTEM)
+            val darkTheme = when (themeMode) {
+                ThemeMode.SYSTEM -> isSystemInDarkTheme()
+                ThemeMode.DARK -> true
+                ThemeMode.LIGHT -> false
+            }
+
+            AlfredTheme(darkTheme = darkTheme) {
                 val colorScheme = MaterialTheme.colorScheme
                 val useLightStatusIcons = colorScheme.surface.luminance() > 0.5f
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,10 @@
 
     <string name="event_list_drawer_title">Alfred</string>
     <string name="event_list_drawer_settings">Settings</string>
+    <string name="event_list_drawer_theme_mode_title">Theme</string>
+    <string name="event_list_theme_mode_system">System default</string>
+    <string name="event_list_theme_mode_light">Light</string>
+    <string name="event_list_theme_mode_dark">Dark</string>
     <string name="event_list_menu_cd">Open navigation</string>
     <string name="event_list_refresh_cd">Refresh timeline</string>
     <string name="event_list_avatar_cd">Open account menu</string>


### PR DESCRIPTION
## Summary
- add a ThemeMode preference stored in SettingsRepository so the choice persists
- surface a theme picker inside the event list navigation drawer and wire it to the new setting
- update all Compose entry activities to observe the theme mode flow and apply AlfredTheme accordingly

## Testing
- `./gradlew :app:lint` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68e0cb67717883339a1793f89dc5c25c